### PR TITLE
Adds verify + secure boolean to ClickhouseCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ your_profile_name:
       user: [user]
       password: [abc123]
       cluster: [cluster name]
+      verify: [verify] # default False
+      secure: [secure] # default False
 ```

--- a/dbt/adapters/clickhouse/connections.py
+++ b/dbt/adapters/clickhouse/connections.py
@@ -26,6 +26,9 @@ class ClickhouseCredentials(Credentials):
     schema: Optional[str] = 'default'
     password: str = ''
     cluster: Optional[str] = None
+    secure: bool = False
+    verify: bool = False
+
 
     @property
     def type(self):
@@ -43,7 +46,7 @@ class ClickhouseCredentials(Credentials):
         self.database = None
 
     def _connection_keys(self):
-        return ('host', 'port', 'user', 'schema')
+        return ('host', 'port', 'user', 'schema', 'secure', 'verify')
 
 
 class ClickhouseConnectionManager(SQLConnectionManager):
@@ -93,6 +96,8 @@ class ClickhouseConnectionManager(SQLConnectionManager):
                 password=credentials.password,
                 client_name=f'dbt-{dbt_version}',
                 connect_timeout=10,
+                secure=credentials.secure,
+                verify=credentials.verify,
                 **kwargs,
             )
             connection.handle = handle

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
 dbt-core==0.19.1
-clickhouse-driver==0.1.5
+clickhouse-driver==0.2.1
 pytest==6.0.2
 pytest-dbt-adapter==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     },
     install_requires=[
         f'dbt-core=={dbt_version}',
-        'clickhouse-driver>=0.1.4',
+        'clickhouse-driver>=0.2.1',
     ],
     python_requires=">=3.6",
     platforms='any',


### PR DESCRIPTION
Allows users to specify clickhouse-driver Client options:
- `secure` if their ClickHouse instance is behind a secure port
- `verify` if ssl verify should be performed.

_(both defaulted to False)_