### PR TITLE
feat: add support for PRIMARY KEY

### DIFF
--- a/dbt/include/clickhouse/macros/adapters.sql
+++ b/dbt/include/clickhouse/macros/adapters.sql
@@ -35,7 +35,7 @@
       {%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}
     )
-  {%- elif engine and engine.startswith('Distributed') -%}
+  {%- elif engine and engine.startswith(('Distributed', 'Join')) -%}
   {%- else %}
     {{ label }} (tuple())
   {%- endif %}


### PR DESCRIPTION
Context from discussion: https://github.com/silentsokolov/dbt-clickhouse/commit/c620ae8e636b9a2c90d01e624be7373d922fc032

Some notes:
- After verifying, `*Log` engines does not support ORDER BY clause. Only engines in the `supported` list and `*MergeTree` support this clause.
- Some engines such as `EmbeddedRocksDB` needs a PRIMARY KEY to work, so I added support in the same commit.

I've tested on `MergeTree`, `Log` and `EmbeddedRocksDB`.